### PR TITLE
Add HEADING2 and fix frame issues novatel dSPACE

### DIFF
--- a/sut-te-bridge/ros2_bridge_ws/src/sut_te_bridge/src/bridge.cpp
+++ b/sut-te-bridge/ros2_bridge_ws/src/sut_te_bridge/src/bridge.cpp
@@ -1616,7 +1616,7 @@ namespace bridge {
 
     heading2.pos_type.type = currentNovatel.heading_2_var.pos_type;
 
-    heading2.length = currentNovatel.heading_2_var.length;
+    heading2.length = 1.9817;  // THIS IS THE EUCLIDEAN DISTANCE BETWEEN PRIMARY (FRONT) AND SECONDARY (REAR) AV24 ONLY
     heading2.heading = currentNovatel.heading_2_var.heading;
     heading2.pitch = currentNovatel.heading_2_var.pitch;
     heading2.reserved = currentNovatel.heading_2_var.reserved;


### PR DESCRIPTION
This pull request introduces a targeted change to the `bridge.cpp` file, specifically updating the value of the `length` field in the `heading2` object to reflect the actual Euclidean distance between the primary (front) and secondary (rear) AV24 units. This adjustment ensures that the reported length is accurate for AV24 vehicles.

Vehicle data accuracy:

* Set `heading2.length` to a fixed value of `1.9817` meters, representing the Euclidean distance between the primary and secondary AV24 units, instead of using the value from `currentNovatel.heading_2_var.length`.