### PR TITLE
Implement gear command adjustments based on current gear state in veh…

### DIFF
--- a/dspace_bridge_ws/src/asm_socketcan_bridge/src/asm_socketcan_bridge.cpp
+++ b/dspace_bridge_ws/src/asm_socketcan_bridge/src/asm_socketcan_bridge.cpp
@@ -1418,6 +1418,13 @@ namespace asm_socketcan_bridge {
   {
     if (this->verbosePrinting)
       RCLCPP_INFO(get_logger(), "sendVehicleFeedbackToSimulation");
+
+    double sim_current_gear = 0.0;
+    {
+      std::shared_lock<std::shared_mutex> bus_lock(can_bus_mutex_);
+      sim_current_gear = canBusStorage_.vehicle_sensors_var.power_train_data_var.current_gear;
+    }
+
     {
       std::lock_guard<std::mutex> lock(feedback_mutex_);
 
@@ -1447,6 +1454,14 @@ namespace asm_socketcan_bridge {
       {
         RCLCPP_INFO(get_logger(), "vehicle_inputs message received.");
         this->stackFeedbackConnectionWarningSent = false;
+      }
+
+      // D-Space's ASM transmission sits in neutral (gear 0) until commanded; our stack uses gears
+      // 1-6. Request 1st gear so it engages a drivable gear. The stack's own gear_shift_cmd
+      // (CAN 1403) overrides this whenever it commands a gear.
+      if (sim_current_gear == 0.0) {
+        this->feedbackCmd.vehicle_inputs.gear_cmd = 1;
+        this->feedbackCmd.vehicle_inputs.enable_gear_cmd = 1;
       }
 
       this->api.sendControlData(22222,std::addressof(this->feedbackCmd),sizeof(this->feedbackCmd));
@@ -2587,14 +2602,7 @@ namespace asm_socketcan_bridge {
       };
       const auto &powertrain = bus.vehicle_sensors_var.power_train_data_var;
       assign("throttle_position", powertrain.throttle_position);
-      // Our stack does not support 0 (neutral) gear.
-      if (powertrain.current_gear == 0.0) {
-        RCLCPP_WARN_STREAM_THROTTLE(
-          this->get_logger(), *this->get_clock(), 1000,
-          "D-Space reported gear=0 (neutral); clamping to 1.");
-      }
-      const auto effective_gear = powertrain.current_gear == 0.0 ? 1.0 : powertrain.current_gear;
-      assign("current_gear", effective_gear);
+      assign("current_gear", powertrain.current_gear);
       assign("engine_speed_rpm", powertrain.engine_rpm);
       assign("vehicle_speed_kmph", powertrain.vehicle_speed_kmph);
       assign("engine_run_switch", powertrain.engine_run_switch_status);
@@ -2604,9 +2612,9 @@ namespace asm_socketcan_bridge {
       {
         const auto commanded = static_cast<double>(this->feedbackCmd.vehicle_inputs.gear_cmd);
         uint8_t synthesized;
-        if (effective_gear < commanded) {
+        if (powertrain.current_gear < commanded) {
           synthesized = 3;  // UPSHIFTING
-        } else if (effective_gear > commanded) {
+        } else if (powertrain.current_gear > commanded) {
           synthesized = 4;  // DOWNSHIFTING
         } else {
           synthesized = 1;  // AVAILABLE

--- a/dspace_bridge_ws/src/asm_socketcan_bridge/src/asm_socketcan_bridge.cpp
+++ b/dspace_bridge_ws/src/asm_socketcan_bridge/src/asm_socketcan_bridge.cpp
@@ -2612,7 +2612,9 @@ namespace asm_socketcan_bridge {
       {
         const auto commanded = static_cast<double>(this->feedbackCmd.vehicle_inputs.gear_cmd);
         uint8_t synthesized;
-        if (powertrain.current_gear < commanded) {
+        if (powertrain.current_gear == 0.0) {
+          synthesized = 1;  // AVAILABLE — neutral is a resting state, not a shift in progress
+        } else if (powertrain.current_gear < commanded) {
           synthesized = 3;  // UPSHIFTING
         } else if (powertrain.current_gear > commanded) {
           synthesized = 4;  // DOWNSHIFTING


### PR DESCRIPTION
This pull request updates how gear handling is managed between the D-Space ASM simulation and the stack, ensuring better alignment and removing unnecessary gear clamping logic. The main changes focus on requesting a drivable gear from the simulation when needed and simplifying how current gear values are processed and reported.

**Simulation gear handling improvements:**

* The code now checks if the simulation is in neutral (gear 0) and automatically requests 1st gear, ensuring the simulation engages a drivable gear unless the stack overrides it with its own command. [[1]](diffhunk://#diff-8b60c85bac93ac0554b1ea168657ae7fa639ad18fbe2739e605c1fe381f932cdR1421-R1427) [[2]](diffhunk://#diff-8b60c85bac93ac0554b1ea168657ae7fa639ad18fbe2739e605c1fe381f932cdR1459-R1466)

**Code simplification and reporting:**

* Removed the logic that clamps reported gear values from 0 (neutral) to 1 and the associated warning message. The actual gear value from the simulation is now reported directly.
* Updated the synthesized gear state logic to use the actual current gear value instead of the previously clamped value, ensuring consistency in gear state reporting.